### PR TITLE
Bump default node version to current LTS

### DIFF
--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "16-bullseye"
+            "default": "18-bullseye"
         }
     },
     "platforms": [

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "18-bullseye"
+            "default": "18"
         }
     },
     "platforms": [

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "16-bullseye"
+            "default": "18-bullseye"
         }
     },
     "platforms": [

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "18-bullseye"
+            "default": "18"
         }
     },
     "platforms": [

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "18-bullseye"
+            "default": "18"
         }
     },
     "platforms": [

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "16-bullseye"
+            "default": "18-bullseye"
         }
     },
     "platforms": [

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "18-bullseye"
+            "default": "18"
         }
     },
     "platforms": [

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -21,7 +21,7 @@
                 "16-buster",
                 "14-buster"
             ],
-            "default": "16-bullseye"
+            "default": "18-bullseye"
         }
     },
     "platforms": [


### PR DESCRIPTION
In October, Node v16 went into maintenance mode with v18 replacing it as the current LTS. This PR bumps the default versions to reflect that.

For reference, here is the official release schedule: https://github.com/nodejs/release#release-schedule
