### PR TITLE
Add info, x-ref on image contents

### DIFF
--- a/src/alpine/NOTES.md
+++ b/src/alpine/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/base:alpine ([source](https://github.com/devcontainers/images/tree/main/src/base-alpine))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/base-alpine/.devcontainer/devcontainer.json))

--- a/src/alpine/README.md
+++ b/src/alpine/README.md
@@ -9,6 +9,10 @@ Simple Alpine container with Git installed.
 |-----|-----|-----|-----|
 | imageVariant | Alpine version: | string | 3.17 |
 
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) with devcontainer.json metadata that will be automatically applied.
+
+* **Image**: mcr.microsoft.com/devcontainers/base:alpine ([source](https://github.com/devcontainers/images/tree/main/src/base-alpine))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/base-alpine/.devcontainer/devcontainer.json))
 
 
 ---

--- a/src/anaconda-postgres/NOTES.md
+++ b/src/anaconda-postgres/NOTES.md
@@ -1,3 +1,9 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/cpp ([source](https://github.com/devcontainers/images/tree/main/src/cpp))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/cpp/.devcontainer/devcontainer.json))
+
+
 ## Using this template
 
 This template creates two containers, one for Anaconda and one for PostgreSQL. You will be connected to the Anaconda container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/.env`. Data is stored in a volume named `postgres-data`.

--- a/src/anaconda/NOTES.md
+++ b/src/anaconda/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/anaconda ([source](https://github.com/devcontainers/images/tree/main/src/anaconda))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/anaconda/.devcontainer/devcontainer.json))
+
 ### Using Conda
 
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/cpp-mariadb/NOTES.md
+++ b/src/cpp-mariadb/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/cpp ([source](https://github.com/devcontainers/images/tree/main/src/cpp))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/cpp/.devcontainer/devcontainer.json))
+
 ### Using Vcpkg
 
 This dev container and its associated image includes a clone of the [`Vcpkg`](https://github.com/microsoft/vcpkg) repo for library packages, and a bootstrapped instance of the [Vcpkg-tool](https://github.com/microsoft/vcpkg-tool) itself.

--- a/src/cpp/NOTES.md
+++ b/src/cpp/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/cpp ([source](https://github.com/devcontainers/images/tree/main/src/cpp))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/cpp/.devcontainer/devcontainer.json))
+
 ### Using Vcpkg
 
 This dev container and its associated image includes a clone of the [`Vcpkg`](https://github.com/microsoft/vcpkg) repo for library packages, and a bootstrapped instance of the [Vcpkg-tool](https://github.com/microsoft/vcpkg-tool) itself.

--- a/src/debian/NOTES.md
+++ b/src/debian/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/base:debian ([source](https://github.com/devcontainers/images/tree/main/src/base-debian))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/base-debian/.devcontainer/devcontainer.json))

--- a/src/docker-in-docker/NOTES.md
+++ b/src/docker-in-docker/NOTES.md
@@ -1,4 +1,4 @@
-## Description
+## Using this template
 
 Dev containers can be useful for all types of applications including those that also deploy into a container based-environment. While you can directly build and run the application inside the dev container you create, you may also want to test it by deploying a built container image into your local Docker Desktop instance without affecting your dev container.
 
@@ -7,3 +7,9 @@ In many cases, the best approach to solve this problem is by bind mounting the d
 This template's approach creates pure "child" containers by hosting its own instance of the docker daemon inside this container.  This is compared to the forementioned "docker-_outside-of_-docker" method (sometimes called docker-from-docker) that bind mounts the host's docker socket, creating "sibling" containers to the current container.
 
 For this technique to work, the "Docker in Docker" Feature included in this template automatically forces the parent container to be run as `--privileged` and adds a `/usr/local/share/docker-init.sh` ENTRYPOINT script that, spawns the `dockerd` process.
+
+The included `.devcontainer.json` can be altered to work with other Debian/Ubuntu-based container images such as `node` or `python`. For example, to use `mcr.microsoft.com/devcontainers/javascript-node`, update the `image` proprty as follows:
+
+```json
+"image": "mcr.microsoft.com/devcontainers/javascript-node:18"
+```

--- a/src/docker-outside-of-docker/NOTES.md
+++ b/src/docker-outside-of-docker/NOTES.md
@@ -1,4 +1,4 @@
-## Description
+## Using this template
 
 Dev containers can be useful for all types of applications including those that also deploy into a container based-environment. While you can directly build and run the application inside the dev container you create, you may also want to test it by deploying a built container image into your local Docker Desktop instance without affecting your dev container.
 

--- a/src/dotnet-fsharp/NOTES.md
+++ b/src/dotnet-fsharp/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/dotnet ([source](https://github.com/devcontainers/images/tree/main/src/dotnet))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/dotnet/.devcontainer/devcontainer.json))

--- a/src/dotnet-mssql/NOTES.md
+++ b/src/dotnet-mssql/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/dotnet ([source](https://github.com/devcontainers/images/tree/main/src/dotnet))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/dotnet/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for C# (.NET) and one for PostgreSQL. You will be connected to the Go container, and from within that container the MS SQL container will be available on **`localhost`** port 1433. The .NET container also includes supporting scripts in the `.devcontainer/mssql` folder used to configure the database. 

--- a/src/dotnet-postgres/NOTES.md
+++ b/src/dotnet-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/dotnet ([source](https://github.com/devcontainers/images/tree/main/src/dotnet))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/dotnet/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for C# (.NET) and one for PostgreSQL. You will be connected to the .NET container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. By default, the `postgre` user password is `postgre`. 

--- a/src/dotnet/NOTES.md
+++ b/src/dotnet/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/dotnet ([source](https://github.com/devcontainers/images/tree/main/src/dotnet))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/dotnet/.devcontainer/devcontainer.json))
+
 ## Enabling HTTPS in ASP.NET using your own dev certificate
 
 To enable HTTPS in ASP.NET, you can export a copy of your local dev certificate.

--- a/src/go-postgres/NOTES.md
+++ b/src/go-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/go ([source](https://github.com/devcontainers/images/tree/main/src/go))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Go and one for PostgreSQL. You will be connected to the Go container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/.env`. Data is stored in a volume named `postgres-data`.

--- a/src/go/NOTES.md
+++ b/src/go/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/go ([source](https://github.com/devcontainers/images/tree/main/src/go))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/devcontainer.json))

--- a/src/java-postgres/NOTES.md
+++ b/src/java-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/java ([source](https://github.com/devcontainers/images/tree/main/src/java))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/java/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Java and one for PostgreSQL. You will be connected to the Java container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/docker-compose.yml`. Data is stored in a volume named `postgres-data`.

--- a/src/java/NOTES.md
+++ b/src/java/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/java ([source](https://github.com/devcontainers/images/tree/main/src/java))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/java/.devcontainer/devcontainer.json))

--- a/src/javascript-node-mongo/NOTES.md
+++ b/src/javascript-node-mongo/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/javascript-node ([source](https://github.com/devcontainers/images/tree/main/src/javascript-node))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Node.js and one for MongoDB. You will be connected to the Node.js container, and from within that container the MongoDB container will be available on on **`localhost`** port 27017 The MongoDB instance can be managed in VS Code via the automatically installed MongoDB extension. Database options can be configured in `.devcontainer/docker-compose.yml` and data is persisted in a volume called `mongo-data`.

--- a/src/javascript-node-postgres/NOTES.md
+++ b/src/javascript-node-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/javascript-node ([source](https://github.com/devcontainers/images/tree/main/src/javascript-node))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This definition creates two containers, one for Node.js and one for PostgreSQL. You will be connected to the Node.js container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.

--- a/src/javascript-node/NOTES.md
+++ b/src/javascript-node/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/javascript-node ([source](https://github.com/devcontainers/images/tree/main/src/javascript-node))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/devcontainer.json))

--- a/src/jekyll/NOTES.md
+++ b/src/jekyll/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/jekyll ([source](https://github.com/devcontainers/images/tree/main/src/jekyll))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/jekyll/.devcontainer/devcontainer.json))

--- a/src/kubernetes-helm-minikube/NOTES.md
+++ b/src/kubernetes-helm-minikube/NOTES.md
@@ -1,8 +1,15 @@
-## Description
+## Using this template
 
 Dev containers can be useful for all types of applications including those that also deploy into a container based-environment. While you can directly build and run the application inside the dev container you create, you may also want to test it by deploying a built container image into a local minikube or remote [Kubernetes](https://kubernetes.io/) cluster without affecting your dev container.
 
 This example illustrates how you can do this by using CLIs ([kubectl](https://kubernetes.io/docs/reference/kubectl/overview/), [Helm](https://helm.sh), Docker), the [Kubernetes extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools), and the [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) right from inside your dev container.  This definition builds up from the [docker-in-docker](../docker-in-docker) container definition along with a [minikube](https://minikube.sigs.k8s.io/docs/) installation that can run right inside the container. It installs the Docker and Kubernetes extensions inside the container so you can use its full feature set with your project.
+
+The included `.devcontainer.json` can be altered to work with other Debian/Ubuntu-based container images such as `node` or `python`. For example, to use `mcr.microsoft.com/devcontainers/javascript-node`, update the `image` proprty as follows:
+
+```json
+"image": "mcr.microsoft.com/devcontainers/javascript-node:18"
+```
+
 
 ## Ingress and port forwarding
 

--- a/src/kubernetes-helm/NOTES.md
+++ b/src/kubernetes-helm/NOTES.md
@@ -1,8 +1,15 @@
-## Description
+## Using this template
 
-> **Note:** If you would prefer to not set up Kubernetes locally, you may find the [Kubernetes - Minikube-in-Docker](../kubernetes-helm-minikube) definition more interesting.
+> **Note:** If you would prefer to not set up Kubernetes locally or are using a cloud-based environment, you may find the [Kubernetes - Minikube-in-Docker](../kubernetes-helm-minikube) definition more interesting.
 
 Dev containers can be useful for all types of applications including those that also deploy into a container based-environment. While you can directly build and run the application inside the dev container you create, you may also want to test it by deploying a built container image into a local minikube or remote [Kubernetes](https://kubernetes.io/) cluster without affecting your dev container.
+
+The included `.devcontainer.json` can be altered to work with other Debian/Ubuntu-based container images such as `node` or `python`. For example, to use `mcr.microsoft.com/devcontainers/javascript-node`, update the `image` proprty as follows:
+
+```json
+"image": "mcr.microsoft.com/devcontainers/javascript-node:18"
+```
+
 
 ## A note on Minikube or otherwise using a local cluster
 

--- a/src/markdown/NOTES.md
+++ b/src/markdown/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/base:debian ([source](https://github.com/devcontainers/images/tree/main/src/base-debian))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/base-debian/.devcontainer/devcontainer.json))

--- a/src/miniconda-postgres/NOTES.md
+++ b/src/miniconda-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/miniconda ([source](https://github.com/devcontainers/images/tree/main/src/miniconda))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/miniconda/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Miniconda and one for PostgreSQL. You will be connected to the Miniconda container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/.env`. Data is stored in a volume named `postgres-data`.

--- a/src/miniconda/NOTES.md
+++ b/src/miniconda/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/miniconda ([source](https://github.com/devcontainers/images/tree/main/src/miniconda))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/miniconda/.devcontainer/devcontainer.json))
+
 ### Using Conda
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).
 

--- a/src/php-mariadb/NOTES.md
+++ b/src/php-mariadb/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/php ([source](https://github.com/devcontainers/images/tree/main/src/php))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/php/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for PHP and one for MariaDB. You will be connected to the PHP container, and from within that container the MariabDB container will be available on **`localhost`** port 3305. The MariaDB database has a default password of `mariadb` and you can update MariaDB parameters by updating the `.devcontainer/docker-compose.yml` file.

--- a/src/php/NOTES.md
+++ b/src/php/NOTES.md
@@ -1,4 +1,9 @@
-### Starting / stopping Apache
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/php ([source](https://github.com/devcontainers/images/tree/main/src/php))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/php/.devcontainer/devcontainer.json))
+
+## Starting / stopping Apache
 
 This dev container includes Apache in addition to the PHP CLI. While you can use PHP's built in CLI (e.g. `php -S 0.0.0.0:8080`), you can start Apache by running:
 

--- a/src/postgres/NOTES.md
+++ b/src/postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/python ([source](https://github.com/devcontainers/images/tree/main/src/python))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/python/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Python and one for PostgreSQL. You will be connected to the Python container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/docker-compose.yml`. Data is stored in a volume named `postgres-data`.

--- a/src/python/NOTES.md
+++ b/src/python/NOTES.md
@@ -1,4 +1,9 @@
-### Installing or updating Python utilities
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/python ([source](https://github.com/devcontainers/images/tree/main/src/python))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/python/.devcontainer/devcontainer.json))
+
+## Installing or updating Python utilities
 
 This container installs all Python development utilities using [pipx](https://pipxproject.github.io/pipx/) to avoid impacting the global Python environment. You can use this same utility add additional utilities in an isolated environment. For example:
 

--- a/src/ruby-rails-postgres/NOTES.md
+++ b/src/ruby-rails-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/ruby ([source](https://github.com/devcontainers/images/tree/main/src/ruby))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/ruby/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Ruby and one for PostgreSQL. You will be connected to the Ruby container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/docker-compose.yml`. Data is stored in a volume named `postgres-data`.

--- a/src/ruby/NOTES.md
+++ b/src/ruby/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/ruby ([source](https://github.com/devcontainers/images/tree/main/src/ruby))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/ruby/.devcontainer/devcontainer.json))

--- a/src/rust-postgres/NOTES.md
+++ b/src/rust-postgres/NOTES.md
@@ -1,3 +1,8 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/rust ([source](https://github.com/devcontainers/images/tree/main/src/rust))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/rust/.devcontainer/devcontainer.json))
+
 ## Using this template
 
 This template creates two containers, one for Rust and one for PostgreSQL. You will be connected to the Rust container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `.devcontainer/.dev`. Data is stored in a volume named `postgres-data`.

--- a/src/rust/NOTES.md
+++ b/src/rust/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/rust ([source](https://github.com/devcontainers/images/tree/main/src/rust))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/rust/.devcontainer/devcontainer.json))

--- a/src/typescript-node/NOTES.md
+++ b/src/typescript-node/NOTES.md
@@ -1,0 +1,4 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/typescript-node ([source](https://github.com/devcontainers/images/tree/main/src/typescript-node))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/typescript-node/.devcontainer/devcontainer.json))

--- a/src/ubuntu/NOTES.md
+++ b/src/ubuntu/NOTES.md
@@ -1,3 +1,7 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/base:ubuntu ([source](https://github.com/devcontainers/images/tree/main/src/base-ubuntu))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/.devcontainer/devcontainer.json))
 ## Using Conda
 
 This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).

--- a/src/universal/NOTES.md
+++ b/src/universal/NOTES.md
@@ -1,0 +1,10 @@
+This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
+
+* **Image**: mcr.microsoft.com/devcontainers/universal ([source](https://github.com/devcontainers/images/tree/main/src/universal))
+* **Applies devcontainer.json contents from image**: Yes ([source](https://github.com/devcontainers/images/blob/main/src/universal/.devcontainer/devcontainer.json))
+
+## Using Conda
+
+This dev container and its associated image includes [the `conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages installed using Conda will be downloaded from Anaconda or another repository if you configure one. To reconfigure Conda in this container to access an alternative repository, please see information on [configuring Conda channels here](https://aka.ms/vscode-remote/conda/channel-setup).
+
+Access to the Anaconda repository is covered by the [Anaconda Terms of Service](https://aka.ms/vscode-remote/conda/terms), which may require some organizations to obtain a commercial license from Anaconda. **However**, when this dev container or its associated image is used with GitHub Codespaces or GitHub Actions, **all users are permitted** to use the Anaconda Repository through the service, including organizations normally required by Anaconda to obtain a paid license for commercial activities. Note that third-party packages may be licensed by their publishers in ways that impact your intellectual property, and are used at your own risk.


### PR DESCRIPTION
This PR adds a cross reference to the associated image for two reasons:

1. To help people find the source code if they want to build their own variation of it.
2. To highlight the devcontainer.json data that will be automatically applied because of the image reference.

(2) is particularly important given it is a very recent change, and developers could be confused when modifying the template to use their own image.

It also fixes the fact that the NOTES.md file for "universal" was accidently under "ubuntu".