### PR TITLE
Fix typo in example of portsAttributes property in all dotnet template files

### DIFF
--- a/src/dotnet-mssql/.devcontainer/devcontainer.json
+++ b/src/dotnet-mssql/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001],
-	// "portsAtributes": {
+	// "portsAttributes": {
 	//		"5001": {
 	//			"protocol": "https"
 	//		}

--- a/src/dotnet-postgres/.devcontainer/devcontainer.json
+++ b/src/dotnet-postgres/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001, 5432],
-	// "portsAtributes": {
+	// "portsAttributes": {
 	//		"5001": {
 	//			"protocol": "https"
 	//		}

--- a/src/dotnet/.devcontainer/devcontainer.json
+++ b/src/dotnet/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001],
-	// "portsAtributes": {
+	// "portsAttributes": {
 	//		"5001": {
 	//			"protocol": "https"
 	//		}


### PR DESCRIPTION
This PR corrects the `portsAtributes` to `portsAttributes` property in the commented out example in `devcontainer.json` template.

Replaces #98 which only corrected one file.