### PR TITLE
Add ctest to path when installing cmake

### DIFF
--- a/src/cpp/.devcontainer/reinstall-cmake.sh
+++ b/src/cpp/.devcontainer/reinstall-cmake.sh
@@ -56,3 +56,4 @@ sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
 sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
 
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest

--- a/src/cpp/devcontainer-template.json
+++ b/src/cpp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "name": "C++",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp",


### PR DESCRIPTION
CTest is used by the CMake Tools VSCode extension (amongst others), but expects the ctest executable to be in the users path, so add a symbolic link to include it.