### PR TITLE
Update devcontainer.json

### DIFF
--- a/src/dotnet-fsharp/.devcontainer/devcontainer.json
+++ b/src/dotnet-fsharp/.devcontainer/devcontainer.json
@@ -16,8 +16,11 @@
 			"extensions": [
 				"Ionide.Ionide-fsharp",
 				"ms-dotnettools.csharp"
-			]
-		}
+			],
+                        "settings": {
+                                "FSharp.dotnetRoot": "/usr/share/dotnet"
+                        }
+		}    
 	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
It looks like the following setting needs to be added to the devcontainer.json:

"FSharp.dotnetRoot": "/usr/share/dotnet"