### PR TITLE
Jekyll - Use updated jekyll image based out of ruby 3.2

### DIFF
--- a/src/jekyll/.devcontainer/devcontainer.json
+++ b/src/jekyll/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Jekyll",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/jekyll:0-${templateOption:imageVariant}"
+	"image": "mcr.microsoft.com/devcontainers/jekyll:1-${templateOption:imageVariant}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/src/jekyll/devcontainer-template.json
+++ b/src/jekyll/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "jekyll",
-    "version": "1.1.4",
+    "version": "2.0.0",
     "name": "Jekyll",
     "description": "Develop static sites with Jekyll, includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/jekyll",


### PR DESCRIPTION
Syncs with https://github.com/devcontainers/images/pull/516 & https://github.com/devcontainers/images/releases/tag/v0.3.2