### PR TITLE
Templates: Ubuntu 18.04 (bionic) - End of Standard Support

### DIFF
--- a/src/cpp-mariadb/devcontainer-template.json
+++ b/src/cpp-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp-mariadb",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "name": "C++ & MariaDB",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp-mariadb",
@@ -9,13 +9,12 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon):",
+            "description": "Debian / Ubuntu version (use Debian 11, Ubuntu 22.04 on local arm64/Apple Silicon):",
             "proposals": [
                 "debian-11",
                 "debian-10",
                 "ubuntu-22.04",
-                "ubuntu-20.04",
-                "ubuntu-18.04"
+                "ubuntu-20.04"
             ],
             "default": "debian-11"
         },

--- a/src/cpp/devcontainer-template.json
+++ b/src/cpp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "C++",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp",
@@ -9,13 +9,12 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/22.04 on local arm64/Apple Silicon):",
+            "description": "Debian / Ubuntu version (use Debian 11, Ubuntu 22.04 on local arm64/Apple Silicon):",
             "proposals": [
                 "debian-11",
                 "debian-10",
                 "ubuntu-22.04",
-                "ubuntu-20.04",
-                "ubuntu-18.04"
+                "ubuntu-20.04"
             ],
             "default": "debian-11"
         },

--- a/src/ubuntu/devcontainer-template.json
+++ b/src/ubuntu/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubuntu",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Ubuntu",
     "description": "A simple Ubuntu container with Git and other common utilities installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ubuntu",
@@ -9,11 +9,10 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon):",
+            "description": "Ubuntu version (use ubuntu-22.04 on local arm64/Apple Silicon):",
             "proposals": [
                 "jammy",
-                "focal",
-                "bionic"
+                "focal"
             ],
             "default": "jammy"
         }


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/issues/567 & https://github.com/devcontainers/images/pull/587

Referring to https://ubuntu.com/blog/18-04-end-of-standard-support, as Ubuntu 18.04 has reached EOSS, we are deprecating support for this image. 