### PR TITLE
Fix typo in dotnet-postgres README

### DIFF
--- a/src/dotnet-postgres/README.md
+++ b/src/dotnet-postgres/README.md
@@ -65,7 +65,7 @@ To enable HTTPS in ASP.NET, you can export a copy of your local dev certificate.
         "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
         "ASPNETCORE_Kestrel__Certificates__Default__Path": "${containerEnv:HOME}/.aspnet/https/aspnetapp.pfx",
     },
-    "portsAttributs": {
+    "portsAttributes": {
         "5001": {
             "protocol": "https"
         }


### PR DESCRIPTION
Before:

<img width="338" alt="Screen Shot 2023-07-22 at 4 37 55 pm" src="https://github.com/devcontainers/templates/assets/24448509/09e16da6-f55f-4f9e-9082-5c723ed99f0d">

After:

<img width="250" alt="Screen Shot 2023-07-22 at 4 38 01 pm" src="https://github.com/devcontainers/templates/assets/24448509/c145cc3b-2f05-49d0-8ec9-d471e78ab6b8">
