### PR TITLE
Go & Go-postgres: Support 1.21 and drop buster

### DIFF
--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go-postgres",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "name": "Go & PostgreSQL",
     "description": "Use and develop Go + Postgres applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go-postgres",

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -9,7 +9,7 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
+            "description": "Go version:",
             "proposals": [
                 "1-bookworm",
                 "1.21-bookworm",

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -14,11 +14,9 @@
                 "1-bookworm",
                 "1.21-bookworm",
                 "1.20-bookworm",
-                "1.19-bookworm",
                 "1-bullseye",
                 "1.21-bullseye",
-                "1.20-bullseye",
-                "1.19-bullseye"
+                "1.20-bullseye"
             ],
             "default": "1.20-bullseye"
         }

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -18,7 +18,7 @@
                 "1.21-bullseye",
                 "1.20-bullseye"
             ],
-            "default": "1.20-bullseye"
+            "default": "1.21-bullseye"
         }
     },
     "platforms": [

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -7,14 +7,16 @@
     "publisher": "Dev Container Spec Maintainers",
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "options": {
-		"imageVariant": {
+        "imageVariant": {
             "type": "string",
             "description": "Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
                 "1-bookworm",
+                "1.21-bookworm",
                 "1.20-bookworm",
                 "1.19-bookworm",
                 "1-bullseye",
+                "1.21-bullseye",
                 "1.20-bullseye",
                 "1.19-bullseye",
                 "1-buster",

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -18,10 +18,7 @@
                 "1-bullseye",
                 "1.21-bullseye",
                 "1.20-bullseye",
-                "1.19-bullseye",
-                "1-buster",
-                "1.20-buster",
-                "1.19-buster"
+                "1.19-bullseye"
             ],
             "default": "1.20-bullseye"
         }

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -9,7 +9,7 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
+            "description": "Go version:",
             "proposals": [
                 "1-bookworm",
                 "1.21-bookworm",

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -14,11 +14,9 @@
                 "1-bookworm",
                 "1.21-bookworm",
                 "1.20-bookworm",
-                "1.19-bookworm",
                 "1-bullseye",
                 "1.21-bullseye",
-                "1.20-bullseye",
-                "1.19-bullseye"
+                "1.20-bullseye"
             ],
             "default": "1.20-bullseye"
         }

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "name": "Go",
     "description": "Develop Go based applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go",

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -18,7 +18,7 @@
                 "1.21-bullseye",
                 "1.20-bullseye"
             ],
-            "default": "1.20-bullseye"
+            "default": "1.21-bullseye"
         }
     },
     "platforms": [

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -7,14 +7,16 @@
     "publisher": "Dev Container Spec Maintainers",
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "options": {
-		"imageVariant": {
+        "imageVariant": {
             "type": "string",
             "description": "Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
                 "1-bookworm",
+                "1.21-bookworm",
                 "1.20-bookworm",
                 "1.19-bookworm",
                 "1-bullseye",
+                "1.21-bullseye",
                 "1.20-bullseye",
                 "1.19-bullseye",
                 "1-buster",

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -18,10 +18,7 @@
                 "1-bullseye",
                 "1.21-bullseye",
                 "1.20-bullseye",
-                "1.19-bullseye",
-                "1-buster",
-                "1.20-buster",
-                "1.19-buster"
+                "1.19-bullseye"
             ],
             "default": "1.20-bullseye"
         }


### PR DESCRIPTION
This PR updates Go to version 1.21 and removes 'buster' from golang tags, following upstream's drop of 'buster' support. Ref: https://github.com/docker-library/golang/commit/cd607138e461368506a6ba50be2163a09b93dab5