### PR TITLE
Seed templates with `dependabot.yml`

### DIFF
--- a/src/alpine/.github/dependabot.yml
+++ b/src/alpine/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/alpine/devcontainer-template.json
+++ b/src/alpine/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "alpine",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Alpine",
     "description": "Simple Alpine container with Git installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/alpine",

--- a/src/anaconda-postgres/.github/dependabot.yml
+++ b/src/anaconda-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/anaconda-postgres/devcontainer-template.json
+++ b/src/anaconda-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda-postgres",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "name": "Anaconda (Python 3) & PostgreSQL",
     "description": "Develop Anaconda & PostgreSQL applications in Python3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/anaconda-postgres",

--- a/src/anaconda/.github/dependabot.yml
+++ b/src/anaconda/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/anaconda/devcontainer-template.json
+++ b/src/anaconda/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "name": "Anaconda (Python 3)",
     "description": "Develop Anaconda applications in Python3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/anaconda",

--- a/src/cpp-mariadb/.github/dependabot.yml
+++ b/src/cpp-mariadb/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/cpp-mariadb/devcontainer-template.json
+++ b/src/cpp-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp-mariadb",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "name": "C++ & MariaDB",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp-mariadb",

--- a/src/cpp/.github/dependabot.yml
+++ b/src/cpp/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/cpp/devcontainer-template.json
+++ b/src/cpp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "name": "C++",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp",

--- a/src/debian/.github/dependabot.yml
+++ b/src/debian/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/debian/devcontainer-template.json
+++ b/src/debian/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "debian",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "name": "Debian",
     "description": "Simple Debian container with Git installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/debian",

--- a/src/docker-existing-docker-compose/.github/dependabot.yml
+++ b/src/docker-existing-docker-compose/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/docker-existing-docker-compose/devcontainer-template.json
+++ b/src/docker-existing-docker-compose/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-existing-docker-compose",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "name": "Existing Docker Compose (Extend)",
     "description": "Sample illustrating how to extend an existing Docker Compose file for use in a dev container.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose",

--- a/src/docker-existing-dockerfile/.github/dependabot.yml
+++ b/src/docker-existing-dockerfile/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/docker-existing-dockerfile/devcontainer-template.json
+++ b/src/docker-existing-dockerfile/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-existing-dockerfile",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "name": "Existing Dockerfile",
     "description": "Sample illustrating reuse of an existing Dockefile.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile",

--- a/src/docker-in-docker/.github/dependabot.yml
+++ b/src/docker-in-docker/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/docker-in-docker/devcontainer-template.json
+++ b/src/docker-in-docker/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "Docker in Docker",
     "description": "Create child containers _inside_ a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-in-docker",

--- a/src/docker-outside-of-docker-compose/.github/dependabot.yml
+++ b/src/docker-outside-of-docker-compose/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/docker-outside-of-docker-compose/devcontainer-template.json
+++ b/src/docker-outside-of-docker-compose/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker-compose",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "name": "Docker outside of Docker Compose",
     "description": "Access your host's Docker install from inside a container when using Docker Compose. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker-compose",

--- a/src/docker-outside-of-docker/.github/dependabot.yml
+++ b/src/docker-outside-of-docker/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/docker-outside-of-docker/devcontainer-template.json
+++ b/src/docker-outside-of-docker/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "Docker outside of Docker",
     "description": "Access your host's Docker install from inside a dev container. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker",

--- a/src/dotnet-fsharp/.github/dependabot.yml
+++ b/src/dotnet-fsharp/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/dotnet-fsharp/devcontainer-template.json
+++ b/src/dotnet-fsharp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-fsharp",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "F# (.NET)",
     "description": "Develop F# and .NET based applications. Includes all needed SDKs, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-fsharp",

--- a/src/dotnet-mssql/.github/dependabot.yml
+++ b/src/dotnet-mssql/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/dotnet-mssql/devcontainer-template.json
+++ b/src/dotnet-mssql/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-mssql",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "C# (.NET) and MS SQL",
     "description": "Develop C# and .NET Core based applications. Includes all needed SDKs, extensions, dependencies and an MS SQL container for parallel database development. Adds an additional MS SQL container to the C# (.NET Core) container definition and deploys any .dacpac files from the mssql .devcontainer folder.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-mssql",

--- a/src/dotnet-postgres/.github/dependabot.yml
+++ b/src/dotnet-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/dotnet-postgres/devcontainer-template.json
+++ b/src/dotnet-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-postgres",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "C# (.NET) and PostgreSQL",
     "description": "Develop C# and .NET Core based applications. Includes all needed SDKs, extensions, dependencies and a PostgreSQL container for parallel database development. Adds an additional PostgreSQL container to the C# (.NET Core) container definition.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-postgres",

--- a/src/dotnet/.github/dependabot.yml
+++ b/src/dotnet/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/dotnet/devcontainer-template.json
+++ b/src/dotnet/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "C# (.NET)",
     "description": "Develop C# and .NET based applications. Includes all needed SDKs, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet",

--- a/src/go-postgres/.github/dependabot.yml
+++ b/src/go-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go-postgres",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Go & PostgreSQL",
     "description": "Use and develop Go + Postgres applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go-postgres",

--- a/src/go/.github/dependabot.yml
+++ b/src/go/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Go",
     "description": "Develop Go based applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go",

--- a/src/java-postgres/.github/dependabot.yml
+++ b/src/java-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/java-postgres/devcontainer-template.json
+++ b/src/java-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java-postgres",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Java & PostgreSQL",
     "description": "Develop applications with Java and PostgreSQL. Includes a Java application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java-postgres",

--- a/src/java/.github/dependabot.yml
+++ b/src/java/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/java/devcontainer-template.json
+++ b/src/java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Java",
     "description": "Develop Java applications. Includes the JDK and Java extensions.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java",

--- a/src/javascript-node-mongo/.github/dependabot.yml
+++ b/src/javascript-node-mongo/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",

--- a/src/javascript-node-postgres/.github/dependabot.yml
+++ b/src/javascript-node-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",

--- a/src/javascript-node/.github/dependabot.yml
+++ b/src/javascript-node/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",

--- a/src/jekyll/.github/dependabot.yml
+++ b/src/jekyll/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/jekyll/devcontainer-template.json
+++ b/src/jekyll/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "jekyll",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "name": "Jekyll",
     "description": "Develop static sites with Jekyll, includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/jekyll",

--- a/src/kubernetes-helm-minikube/.github/dependabot.yml
+++ b/src/kubernetes-helm-minikube/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/kubernetes-helm-minikube/devcontainer-template.json
+++ b/src/kubernetes-helm-minikube/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "kubernetes-helm-minikube",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "name": "Kubernetes - Minikube-in-Docker",
     "description": "Access an embedded minikube instance or remote a Kubernetes cluster from inside a dev container. Includes kubectl, Helm, minikube, and the Docker.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube",

--- a/src/kubernetes-helm/.github/dependabot.yml
+++ b/src/kubernetes-helm/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/kubernetes-helm/devcontainer-template.json
+++ b/src/kubernetes-helm/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "kubernetes-helm",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "name": "Kubernetes - Local Configuration",
     "description": "Access a local (or remote) Kubernetes cluster from inside a dev container using your local config. Includes kubectl, Helm, and the Docker CLI.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm",

--- a/src/markdown/.github/dependabot.yml
+++ b/src/markdown/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/markdown/devcontainer-template.json
+++ b/src/markdown/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "markdown",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Markdown",
     "description": "A simple container for editing markdown.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/markdown",

--- a/src/miniconda-postgres/.github/dependabot.yml
+++ b/src/miniconda-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/miniconda-postgres/devcontainer-template.json
+++ b/src/miniconda-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "miniconda-postgres",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "name": "Miniconda & PostgreSQL (Python 3)",
     "description": "Develop Miniconda & PostgreSQL applications in Python 3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/miniconda-postgres",

--- a/src/miniconda/.github/dependabot.yml
+++ b/src/miniconda/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/miniconda/devcontainer-template.json
+++ b/src/miniconda/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "miniconda",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "name": "Miniconda (Python 3)",
     "description": "Develop Miniconda applications in Python 3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/miniconda",

--- a/src/php-mariadb/.github/dependabot.yml
+++ b/src/php-mariadb/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/php-mariadb/devcontainer-template.json
+++ b/src/php-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php-mariadb",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "PHP & MariaDB",
     "description": "Develop PHP applications with MariaDB (MySQL Compatible).",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php-mariadb",

--- a/src/php/.github/dependabot.yml
+++ b/src/php/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/php/devcontainer-template.json
+++ b/src/php/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "PHP",
     "description": "Develop PHP based applications. Includes needed tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php",

--- a/src/postgres/.github/dependabot.yml
+++ b/src/postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/postgres/devcontainer-template.json
+++ b/src/postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "postgres",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "name": "Python 3 & PostgreSQL",
     "description": "Develop applications with Python 3 and PostgreSQL. Includes a Python application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/postgres",

--- a/src/powershell/.github/dependabot.yml
+++ b/src/powershell/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/powershell/devcontainer-template.json
+++ b/src/powershell/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "Powershell",
     "description": "Develop PowerShell scripts without installing anything locally.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/powershell",

--- a/src/python/.github/dependabot.yml
+++ b/src/python/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/python/devcontainer-template.json
+++ b/src/python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "python",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Python 3",
     "description": "Develop Python 3 applications.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/python",

--- a/src/ruby-rails-postgres/.github/dependabot.yml
+++ b/src/ruby-rails-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/ruby-rails-postgres/devcontainer-template.json
+++ b/src/ruby-rails-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby-rails-postgres",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Ruby on Rails & Postgres",
     "description": "Develop Ruby on Rails applications with Postgres. Includes a Rails application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby-rails-postgres",

--- a/src/ruby/.github/dependabot.yml
+++ b/src/ruby/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/ruby/devcontainer-template.json
+++ b/src/ruby/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Ruby",
     "description": "Develop Ruby based applications. includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby",

--- a/src/rust-postgres/.github/dependabot.yml
+++ b/src/rust-postgres/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/rust-postgres/devcontainer-template.json
+++ b/src/rust-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust-postgres",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "name": "Rust & PostgreSQL",
     "description": "Develop applications with Rust and PostgreSQL. Includes a Rust application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust-postgres",

--- a/src/rust/.github/dependabot.yml
+++ b/src/rust/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/rust/devcontainer-template.json
+++ b/src/rust/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "name": "Rust",
     "description": "Develop Rust based applications. Includes appropriate runtime args and everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust",

--- a/src/typescript-node/.github/dependabot.yml
+++ b/src/typescript-node/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",

--- a/src/ubuntu/.github/dependabot.yml
+++ b/src/ubuntu/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/ubuntu/devcontainer-template.json
+++ b/src/ubuntu/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubuntu",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "Ubuntu",
     "description": "A simple Ubuntu container with Git and other common utilities installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ubuntu",

--- a/src/universal/.github/dependabot.yml
+++ b/src/universal/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/src/universal/devcontainer-template.json
+++ b/src/universal/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "universal",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Default Linux Universal",
     "description": "Use or extend the new Ubuntu-based default, large, multi-language universal container for GitHub Codespaces.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/universal",


### PR DESCRIPTION
Given https://containers.dev/guide/dependabot is now GA, make it as easy as possible for folks to stay up-to-date with Feature updates with Dependabot!

refs: https://github.com/github/codespaces/issues/15875,https://github.com/dependabot/dependabot-core/issues/7000,https://github.com/dependabot/dependabot-core/issues/7000

I recognize it's opinionated to add a `.github` folder, but given the tight integration with dependabot here (without community alternatives at the moment) I think it's OK.   Please feel free to share your thoughts in a discussion (and we're open to considering other additions to these templates if it highly enriches the experience on other platforms!)