### PR TITLE
PHP-mariaDB: Update Template default to "8.2-bookworm"

### DIFF
--- a/src/php-mariadb/devcontainer-template.json
+++ b/src/php-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php-mariadb",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "name": "PHP & MariaDB",
     "description": "Develop PHP applications with MariaDB (MySQL Compatible).",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php-mariadb",
@@ -21,7 +21,7 @@
                 "8.2-buster",
                 "8.1-buster"
             ],
-            "default": "8.2-bullseye"
+            "default": "8.2-bookworm"
         }
     },
     "platforms": [


### PR DESCRIPTION
Closes: https://github.com/devcontainers/templates/issues/233

When `bookworm` was newly supported, I remember [php-mariadb](https://github.com/devcontainers/templates/tree/main/src/php-mariadb) failing with `mySQL` errors as it didn't immediately support it. Hence, we kept the default as `bullseye`.
