### PR TITLE
[Ruby, Ruby-rails-postgres] - EOL 3.0 changes

### DIFF
--- a/src/ruby-rails-postgres/devcontainer-template.json
+++ b/src/ruby-rails-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby-rails-postgres",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "name": "Ruby on Rails & Postgres",
     "description": "Develop Ruby on Rails applications with Postgres. Includes a Rails application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby-rails-postgres",
@@ -19,11 +19,9 @@
 				"3.3-bullseye",
 				"3.2-bullseye",
                 "3.1-bullseye",
-                "3.0-bullseye",
                 "3-buster",
 				"3.2-buster",
-                "3.1-buster",
-                "3.0-buster"
+                "3.1-buster"
             ],
             "default": "3.3-bullseye"
         }

--- a/src/ruby/devcontainer-template.json
+++ b/src/ruby/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "name": "Ruby",
     "description": "Develop Ruby based applications. includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby",
@@ -19,11 +19,9 @@
 				"3.3-bullseye",
 				"3.2-bullseye",
                 "3.1-bullseye",
-                "3.0-bullseye",
                 "3-buster",
 				"3.2-buster",
-                "3.1-buster",
-                "3.0-buster"
+                "3.1-buster"
             ],
             "default": "3.3-bullseye"
         }


### PR DESCRIPTION
**Templates names**:
 
 * `Ruby`, `Ruby-Rails-Postgres`
 
 **Description**:
 
 This PR achieves the following :
 
 * made corresponding changes for `Ruby` as well as `Ruby-rails-postgres` for `Ruby 3.0 EOL`;
 
 _Changelog_:
 
 * Updated corresponding `devcontainer-template.json's` for both templates
   * Updated patch version to bump up the version of the templates;
   * Removed all `3.0 versions` from the corresponding files for the templates;