### PR TITLE
Fix postCreateCommand.sh

### DIFF
--- a/src/dotnet-mssql/.devcontainer/mssql/postCreateCommand.sh
+++ b/src/dotnet-mssql/.devcontainer/mssql/postCreateCommand.sh
@@ -58,7 +58,7 @@ then
         then
             dbname=$(basename $f ".dacpac")
             echo "Deploying dacpac $f"
-            /opt/sqlpackage/sqlpackage /Action:Publish /SourceFile:$f /TargetServerName:localhost /TargetDatabaseName:$dbname /TargetUser:sa /TargetPassword:$SApassword
+            /opt/sqlpackage/sqlpackage /Action:Publish /SourceFile:$f /TargetTrustServerCertificate:True /TargetServerName:db /TargetDatabaseName:$dbname /TargetUser:sa /TargetPassword:$SApassword
         fi
     done
 fi

--- a/src/dotnet-mssql/devcontainer-template.json
+++ b/src/dotnet-mssql/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-mssql",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "name": "C# (.NET) and MS SQL",
     "description": "Develop C# and .NET Core based applications. Includes all needed SDKs, extensions, dependencies and an MS SQL container for parallel database development. Adds an additional MS SQL container to the C# (.NET Core) container definition and deploys any .dacpac files from the mssql .devcontainer folder.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-mssql",


### PR DESCRIPTION
When using a dacpac like inscribed to do the server should be accessed using the `db` name instead of `localhost` and also the ceritifcate (since it is self signed when using this devcontainer) should be trusted, otherwise it will fail