### PR TITLE
[templates] - buster - eol changes

### DIFF
--- a/src/debian/devcontainer-template.json
+++ b/src/debian/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "debian",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "name": "Debian",
     "description": "Simple Debian container with Git installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/debian",
@@ -12,8 +12,7 @@
             "description": "Debian version (use bookworm or bullseye on local arm64/Apple Silicon):",
             "proposals": [
 				"bookworm",
-                "bullseye",
-                "buster"
+                "bullseye"
             ],
             "default": "bullseye"
         }

--- a/src/java-postgres/devcontainer-template.json
+++ b/src/java-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java-postgres",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "name": "Java & PostgreSQL",
     "description": "Develop applications with Java and PostgreSQL. Includes a Java application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java-postgres",
@@ -18,11 +18,7 @@
 				"21-bullseye",
                 "17-bullseye",
                 "11-bullseye",
-                "8-bullseye",
-				"21-buster",
-                "17-buster",
-                "11-buster",
-                "8-buster"
+                "8-bullseye"
             ],
             "default": "21-bullseye"
         },

--- a/src/java/devcontainer-template.json
+++ b/src/java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "name": "Java",
     "description": "Develop Java applications. Includes the JDK and Java extensions.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java",
@@ -18,11 +18,7 @@
 				"21-bullseye",
                 "17-bullseye",
                 "11-bullseye",
-                "8-bullseye",
-				"21-buster",
-                "17-buster",
-                "11-buster",
-                "8-buster"
+                "8-bullseye"
             ],
             "default": "21-bullseye"
         },

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -15,9 +15,7 @@
 				"22-bullseye",
 				"20-bookworm",
 				"20-bullseye",
-                "18-bullseye",
-				"20-buster",
-                "18-buster"
+                "18-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -17,9 +17,7 @@
 				"20-bullseye",
                 "18-bookworm",
 				"20-bullseye",
-                "18-bullseye",
-				"20-buster",
-                "18-buster"
+                "18-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -17,9 +17,7 @@
 				"20-bullseye",
                 "18-bookworm",
 				"20-bullseye",
-                "18-bullseye",
-				"20-buster",
-                "18-buster"
+                "18-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/php-mariadb/devcontainer-template.json
+++ b/src/php-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php-mariadb",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "name": "PHP & MariaDB",
     "description": "Develop PHP applications with MariaDB (MySQL Compatible).",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php-mariadb",
@@ -16,10 +16,7 @@
                 "8.1-bookworm",
                 "8-bullseye",
                 "8.2-bullseye",
-                "8.1-bullseye",
-                "8-buster",
-                "8.2-buster",
-                "8.1-buster"
+                "8.1-bullseye"
             ],
             "default": "8.2-bookworm"
         }

--- a/src/php/devcontainer-template.json
+++ b/src/php/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "name": "PHP",
     "description": "Develop PHP based applications. Includes needed tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php",
@@ -16,10 +16,7 @@
                 "8.1-bookworm",
                 "8-bullseye",
                 "8.2-bullseye",
-                "8.1-bullseye",
-                "8-buster",
-                "8.2-buster",
-                "8.1-buster"
+                "8.1-bullseye"
             ],
             "default": "8.2-bullseye"
         }

--- a/src/python/devcontainer-template.json
+++ b/src/python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "python",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "name": "Python 3",
     "description": "Develop Python 3 applications.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/python",
@@ -22,12 +22,7 @@
                 "3.11-bullseye",
                 "3.10-bullseye",
                 "3.9-bullseye",
-                "3.8-bullseye",
-                "3-buster",
-                "3.11-buster",
-                "3.10-buster",
-                "3.9-buster",
-                "3.8-buster"
+                "3.8-bullseye"
             ],
             "default": "3.12-bullseye"
         }

--- a/src/ruby-rails-postgres/devcontainer-template.json
+++ b/src/ruby-rails-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby-rails-postgres",
-    "version": "3.1.1",
+    "version": "4.0.0",
     "name": "Ruby on Rails & Postgres",
     "description": "Develop Ruby on Rails applications with Postgres. Includes a Rails application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby-rails-postgres",
@@ -18,10 +18,7 @@
                 "3-bullseye",
 				"3.3-bullseye",
 				"3.2-bullseye",
-                "3.1-bullseye",
-                "3-buster",
-				"3.2-buster",
-                "3.1-buster"
+                "3.1-bullseye"
             ],
             "default": "3.3-bullseye"
         }

--- a/src/ruby/devcontainer-template.json
+++ b/src/ruby/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "3.1.1",
+    "version": "4.0.0",
     "name": "Ruby",
     "description": "Develop Ruby based applications. includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby",
@@ -18,10 +18,7 @@
                 "3-bullseye",
 				"3.3-bullseye",
 				"3.2-bullseye",
-                "3.1-bullseye",
-                "3-buster",
-				"3.2-buster",
-                "3.1-buster"
+                "3.1-bullseye"
             ],
             "default": "3.3-bullseye"
         }

--- a/src/rust-postgres/devcontainer-template.json
+++ b/src/rust-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust-postgres",
-    "version": "2.1.0",
+    "version": "4.0.0",
     "name": "Rust & PostgreSQL",
     "description": "Develop applications with Rust and PostgreSQL. Includes a Rust application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust-postgres",
@@ -12,7 +12,6 @@
             "description": "Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon):",
             "proposals": [
 				"bookworm",
-                "buster",
                 "bullseye"
             ],
             "default": "bullseye"

--- a/src/rust/devcontainer-template.json
+++ b/src/rust/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "2.1.0",
+    "version": "4.0.0",
     "name": "Rust",
     "description": "Develop Rust based applications. Includes appropriate runtime args and everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust",
@@ -12,7 +12,6 @@
             "description": "Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon):",
             "proposals": [
 				"bookworm",
-                "buster",
                 "bullseye"
             ],
             "default": "bullseye"

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "3.2.0",
+    "version": "4.0.0",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -16,9 +16,7 @@
 				"20-bookworm",
                 "18-bookworm",
 				"20-bullseye",
-                "18-bullseye",
-				"20-buster",
-                "18-buster"
+                "18-bullseye"
             ],
             "default": "22-bookworm"
         }


### PR DESCRIPTION
**Templates Names**

* debian
* java
* java-postgres
* javascript-node
* javascript-node-mongo
* javascript-node-postgres
* php
* php-mariadb
* python
* ruby
* ruby-rails-postgres
* rust
* rust-postgres
* typescript-node


**Changes**

* Changes appropriate for `Buster` EOL - to the `devcontainer-template.json` files have been made for the above templates


**Checklist**

* [x] Checked that applied changes work as expected