### PR TITLE
Prefer `sleep infinity` to `while sleep 1000`

### DIFF
--- a/src/docker-existing-docker-compose/.devcontainer/docker-compose.yml
+++ b/src/docker-existing-docker-compose/.devcontainer/docker-compose.yml
@@ -22,5 +22,5 @@ services:
     #   - seccomp:unconfined
 
     # Overrides default command so things don't shut down after the process ends.
-    command: /bin/sh -c "while sleep 1000; do :; done"
+    command: sleep infinity
  

--- a/src/docker-existing-docker-compose/devcontainer-template.json
+++ b/src/docker-existing-docker-compose/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-existing-docker-compose",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Existing Docker Compose (Extend)",
     "description": "Sample illustrating how to extend an existing Docker Compose file for use in a dev container.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose",


### PR DESCRIPTION
Other templates seem to use `sleep infinity`, so why not do so here as well?

- https://github.com/search?q=repo%3Adevcontainers%2Ftemplates%20sleep&type=code