### PR TITLE
seed `optionalPaths` property into Templates

### DIFF
--- a/src/alpine/devcontainer-template.json
+++ b/src/alpine/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "alpine",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "name": "Alpine",
     "description": "Simple Alpine container with Git installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/alpine",
@@ -11,9 +11,9 @@
             "type": "string",
             "description": "Alpine version:",
             "proposals": [
-				"3.20",
-				"3.19",
-				"3.18",
+                "3.20",
+                "3.19",
+                "3.18",
                 "3.17"
             ],
             "default": "3.20"
@@ -21,5 +21,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/anaconda-postgres/devcontainer-template.json
+++ b/src/anaconda-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda-postgres",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Anaconda (Python 3) & PostgreSQL",
     "description": "Develop Anaconda & PostgreSQL applications in Python3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/anaconda-postgres",
@@ -9,5 +9,8 @@
     "platforms": [
         "Python",
         "Anaconda"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/anaconda/devcontainer-template.json
+++ b/src/anaconda/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Anaconda (Python 3)",
     "description": "Develop Anaconda applications in Python3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/anaconda",
@@ -9,5 +9,8 @@
     "platforms": [
         "Python",
         "Anaconda"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/cpp-mariadb/devcontainer-template.json
+++ b/src/cpp-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp-mariadb",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "name": "C++ & MariaDB",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp-mariadb",
@@ -11,9 +11,9 @@
             "type": "string",
             "description": "Debian / Ubuntu version (use Debian 12, Debian 11, Ubuntu 24.04, and Ubuntu 22.04 on local arm64/Apple Silicon):",
             "proposals": [
-				"debian-12",
+                "debian-12",
                 "debian-11",
-				"ubuntu-24.04",
+                "ubuntu-24.04",
                 "ubuntu-22.04",
                 "ubuntu-20.04"
             ],
@@ -32,5 +32,8 @@
     },
     "platforms": [
         "C++"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/cpp/devcontainer-template.json
+++ b/src/cpp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "name": "C++",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp",
@@ -11,9 +11,9 @@
             "type": "string",
             "description": "Debian / Ubuntu version (use Debian 12, Debian 11, Ubuntu 24.04, and Ubuntu 22.04 on local arm64/Apple Silicon):",
             "proposals": [
-				"debian-12",
+                "debian-12",
                 "debian-11",
-				"ubuntu-24.04",
+                "ubuntu-24.04",
                 "ubuntu-22.04",
                 "ubuntu-20.04"
             ],
@@ -32,5 +32,8 @@
     },
     "platforms": [
         "C++"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/debian/devcontainer-template.json
+++ b/src/debian/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "debian",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "name": "Debian",
     "description": "Simple Debian container with Git installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/debian",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Debian version (use bookworm or bullseye on local arm64/Apple Silicon):",
             "proposals": [
-				"bookworm",
+                "bookworm",
                 "bullseye"
             ],
             "default": "bullseye"
@@ -19,5 +19,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/docker-existing-docker-compose/devcontainer-template.json
+++ b/src/docker-existing-docker-compose/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-existing-docker-compose",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "name": "Existing Docker Compose (Extend)",
     "description": "Sample illustrating how to extend an existing Docker Compose file for use in a dev container.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/docker-existing-dockerfile/devcontainer-template.json
+++ b/src/docker-existing-dockerfile/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-existing-dockerfile",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Existing Dockerfile",
     "description": "Sample illustrating reuse of an existing Dockefile.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/docker-in-docker/devcontainer-template.json
+++ b/src/docker-in-docker/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Docker in Docker",
     "description": "Create child containers _inside_ a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-in-docker",
@@ -40,5 +40,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/docker-outside-of-docker-compose/devcontainer-template.json
+++ b/src/docker-outside-of-docker-compose/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker-compose",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "name": "Docker outside of Docker Compose",
     "description": "Access your host's Docker install from inside a container when using Docker Compose. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker-compose",
@@ -40,5 +40,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/docker-outside-of-docker/devcontainer-template.json
+++ b/src/docker-outside-of-docker/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Docker outside of Docker",
     "description": "Access your host's Docker install from inside a dev container. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-outside-of-docker",
@@ -40,5 +40,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/dotnet-fsharp/devcontainer-template.json
+++ b/src/dotnet-fsharp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-fsharp",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "name": "F# (.NET)",
     "description": "Develop F# and .NET based applications. Includes all needed SDKs, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-fsharp",
@@ -10,5 +10,8 @@
         ".NET",
         ".NET Core",
         "F#"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/dotnet-mssql/devcontainer-template.json
+++ b/src/dotnet-mssql/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-mssql",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "name": "C# (.NET) and MS SQL",
     "description": "Develop C# and .NET Core based applications. Includes all needed SDKs, extensions, dependencies and an MS SQL container for parallel database development. Adds an additional MS SQL container to the C# (.NET Core) container definition and deploys any .dacpac files from the mssql .devcontainer folder.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-mssql",
@@ -11,15 +11,15 @@
             "type": "string",
             "description": ".NET version:",
             "proposals": [
-				"8.0",
+                "8.0",
                 "7.0",
                 "6.0",
-				"8.0-bookworm",
+                "8.0-bookworm",
                 "7.0-bookworm",
                 "6.0-bookworm",
                 "7.0-bullseye",
                 "6.0-bullseye",
-				"8.0-jammy",
+                "8.0-jammy",
                 "7.0-jammy",
                 "6.0-jammy",
                 "6.0-focal"
@@ -32,5 +32,8 @@
         ".NET Core",
         "C#",
         "Microsoft SQL"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/dotnet-postgres/devcontainer-template.json
+++ b/src/dotnet-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet-postgres",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "name": "C# (.NET) and PostgreSQL",
     "description": "Develop C# and .NET Core based applications. Includes all needed SDKs, extensions, dependencies and a PostgreSQL container for parallel database development. Adds an additional PostgreSQL container to the C# (.NET Core) container definition.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet-postgres",
@@ -11,15 +11,15 @@
             "type": "string",
             "description": ".NET version:",
             "proposals": [
-				"8.0",
+                "8.0",
                 "7.0",
                 "6.0",
-				"8.0-bookworm",
+                "8.0-bookworm",
                 "7.0-bookworm",
                 "6.0-bookworm",
                 "7.0-bullseye",
                 "6.0-bullseye",
-				"8.0-jammy",
+                "8.0-jammy",
                 "7.0-jammy",
                 "6.0-jammy",
                 "6.0-focal"
@@ -32,5 +32,8 @@
         ".NET Core",
         "C#",
         "PostgreSQL"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/dotnet/devcontainer-template.json
+++ b/src/dotnet/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "name": "C# (.NET)",
     "description": "Develop C# and .NET based applications. Includes all needed SDKs, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/dotnet",
@@ -11,15 +11,15 @@
             "type": "string",
             "description": ".NET version:",
             "proposals": [
-				"8.0",
+                "8.0",
                 "7.0",
                 "6.0",
-				"8.0-bookworm",
+                "8.0-bookworm",
                 "7.0-bookworm",
                 "6.0-bookworm",
                 "7.0-bullseye",
                 "6.0-bullseye",
-				"8.0-jammy",
+                "8.0-jammy",
                 "7.0-jammy",
                 "6.0-jammy",
                 "6.0-focal"
@@ -31,5 +31,8 @@
         ".NET",
         ".NET Core",
         "C#"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go-postgres",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Go & PostgreSQL",
     "description": "Use and develop Go + Postgres applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go-postgres",
@@ -12,10 +12,10 @@
             "description": "Go version:",
             "proposals": [
                 "1-bookworm",
-				"1.22-bookworm",
+                "1.22-bookworm",
                 "1.21-bookworm",
                 "1-bullseye",
-				"1.22-bullseye",
+                "1.22-bullseye",
                 "1.21-bullseye"
             ],
             "default": "1.22-bookworm"
@@ -23,5 +23,8 @@
     },
     "platforms": [
         "Go"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Go",
     "description": "Develop Go based applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go",
@@ -12,10 +12,10 @@
             "description": "Go version:",
             "proposals": [
                 "1-bookworm",
-				"1.22-bookworm",
+                "1.22-bookworm",
                 "1.21-bookworm",
                 "1-bullseye",
-				"1.22-bullseye",
+                "1.22-bullseye",
                 "1.21-bullseye"
             ],
             "default": "1.22-bookworm"
@@ -23,5 +23,8 @@
     },
     "platforms": [
         "Go"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/java-postgres/devcontainer-template.json
+++ b/src/java-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java-postgres",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Java & PostgreSQL",
     "description": "Develop applications with Java and PostgreSQL. Includes a Java application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java-postgres",
@@ -11,11 +11,11 @@
             "type": "string",
             "description": "Java version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"21-bookworm",
+                "21-bookworm",
                 "17-bookworm",
                 "11-bookworm",
                 "8-bookworm",
-				"21-bullseye",
+                "21-bullseye",
                 "17-bullseye",
                 "11-bullseye",
                 "8-bullseye"
@@ -35,5 +35,8 @@
     },
     "platforms": [
         "Java"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/java/devcontainer-template.json
+++ b/src/java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "java",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Java",
     "description": "Develop Java applications. Includes the JDK and Java extensions.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java",
@@ -11,11 +11,11 @@
             "type": "string",
             "description": "Java version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"21-bookworm",
+                "21-bookworm",
                 "17-bookworm",
                 "11-bookworm",
                 "8-bookworm",
-				"21-bullseye",
+                "21-bullseye",
                 "17-bullseye",
                 "11-bullseye",
                 "8-bullseye"
@@ -35,5 +35,8 @@
     },
     "platforms": [
         "Java"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -11,10 +11,10 @@
             "type": "string",
             "description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"22-bookworm",
-				"22-bullseye",
-				"20-bookworm",
-				"20-bullseye",
+                "22-bookworm",
+                "22-bullseye",
+                "20-bookworm",
+                "20-bullseye",
                 "18-bullseye"
             ],
             "default": "22-bookworm"
@@ -24,5 +24,8 @@
         "Node.js",
         "JavaScript",
         "Mongo DB"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -11,12 +11,12 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"22-bookworm",
-				"22-bullseye",
-				"20-bookworm",
-				"20-bullseye",
+                "22-bookworm",
+                "22-bullseye",
+                "20-bookworm",
+                "20-bullseye",
                 "18-bookworm",
-				"20-bullseye",
+                "20-bullseye",
                 "18-bullseye"
             ],
             "default": "22-bookworm"
@@ -26,5 +26,8 @@
         "Node.js",
         "JavaScript",
         "PostgreSQL DB"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -11,12 +11,12 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"22-bookworm",
-				"22-bullseye",
-				"20-bookworm",
-				"20-bullseye",
+                "22-bookworm",
+                "22-bullseye",
+                "20-bookworm",
+                "20-bullseye",
                 "18-bookworm",
-				"20-bullseye",
+                "20-bullseye",
                 "18-bullseye"
             ],
             "default": "22-bookworm"
@@ -25,5 +25,8 @@
     "platforms": [
         "Node.js",
         "JavaScript"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/jekyll/devcontainer-template.json
+++ b/src/jekyll/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "jekyll",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "name": "Jekyll",
     "description": "Develop static sites with Jekyll, includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/jekyll",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon):",
             "proposals": [
-				"bookworm",
+                "bookworm",
                 "bullseye",
                 "buster"
             ],
@@ -21,5 +21,8 @@
     "platforms": [
         "Ruby",
         "Jekyll"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/kubernetes-helm-minikube/devcontainer-template.json
+++ b/src/kubernetes-helm-minikube/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "kubernetes-helm-minikube",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "name": "Kubernetes - Minikube-in-Docker",
     "description": "Access an embedded minikube instance or remote a Kubernetes cluster from inside a dev container. Includes kubectl, Helm, minikube, and the Docker.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/kubernetes-helm/devcontainer-template.json
+++ b/src/kubernetes-helm/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "kubernetes-helm",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "name": "Kubernetes - Local Configuration",
     "description": "Access a local (or remote) Kubernetes cluster from inside a dev container using your local config. Includes kubectl, Helm, and the Docker CLI.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/markdown/devcontainer-template.json
+++ b/src/markdown/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "markdown",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Markdown",
     "description": "A simple container for editing markdown.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/markdown",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "Markdown"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/miniconda-postgres/devcontainer-template.json
+++ b/src/miniconda-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "miniconda-postgres",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Miniconda & PostgreSQL (Python 3)",
     "description": "Develop Miniconda & PostgreSQL applications in Python 3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/miniconda-postgres",
@@ -10,5 +10,8 @@
         "Python",
         "Anaconda",
         "Miniconda"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/miniconda/devcontainer-template.json
+++ b/src/miniconda/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "miniconda",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Miniconda (Python 3)",
     "description": "Develop Miniconda applications in Python 3. Installs dependencies from your environment.yml file and the Python extension.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/miniconda",
@@ -10,5 +10,8 @@
         "Python",
         "Anaconda",
         "Miniconda"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/php-mariadb/devcontainer-template.json
+++ b/src/php-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php-mariadb",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "PHP & MariaDB",
     "description": "Develop PHP applications with MariaDB (MySQL Compatible).",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php-mariadb",
@@ -24,5 +24,8 @@
     "platforms": [
         "PHP",
         "MariaDB (MySQL Compatible)"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/php/devcontainer-template.json
+++ b/src/php/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "PHP",
     "description": "Develop PHP based applications. Includes needed tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/php",
@@ -23,5 +23,8 @@
     },
     "platforms": [
         "PHP"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/postgres/devcontainer-template.json
+++ b/src/postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "postgres",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "name": "Python 3 & PostgreSQL",
     "description": "Develop applications with Python 3 and PostgreSQL. Includes a Python application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/postgres",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Python version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"3-bookworm",
+                "3-bookworm",
                 "3.11-bookworm",
                 "3.10-bookworm",
                 "3.9-bookworm",
@@ -32,5 +32,8 @@
     },
     "platforms": [
         "Python"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/powershell/devcontainer-template.json
+++ b/src/powershell/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Powershell",
     "description": "Develop PowerShell scripts without installing anything locally.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/powershell",
@@ -8,5 +8,8 @@
     "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
     "platforms": [
         "PowerShell"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/python/devcontainer-template.json
+++ b/src/python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "python",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Python 3",
     "description": "Develop Python 3 applications.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/python",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Python version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"3-bookworm",
+                "3-bookworm",
                 "3.12-bookworm",
                 "3.11-bookworm",
                 "3.10-bookworm",
@@ -29,5 +29,8 @@
     },
     "platforms": [
         "Python"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/ruby-rails-postgres/devcontainer-template.json
+++ b/src/ruby-rails-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby-rails-postgres",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Ruby on Rails & Postgres",
     "description": "Develop Ruby on Rails applications with Postgres. Includes a Rails application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby-rails-postgres",
@@ -12,12 +12,12 @@
             "description": "Ruby version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
                 "3-bookworm",
-				"3.3-bookworm",
-				"3.2-bookworm",
+                "3.3-bookworm",
+                "3.2-bookworm",
                 "3.1-bookworm",
                 "3-bullseye",
-				"3.3-bullseye",
-				"3.2-bullseye",
+                "3.3-bullseye",
+                "3.2-bullseye",
                 "3.1-bullseye"
             ],
             "default": "3.3-bullseye"
@@ -25,5 +25,8 @@
     },
     "platforms": [
         "Ruby"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/ruby/devcontainer-template.json
+++ b/src/ruby/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Ruby",
     "description": "Develop Ruby based applications. includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby",
@@ -12,12 +12,12 @@
             "description": "Ruby version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
                 "3-bookworm",
-				"3.3-bookworm",
-				"3.2-bookworm",
+                "3.3-bookworm",
+                "3.2-bookworm",
                 "3.1-bookworm",
                 "3-bullseye",
-				"3.3-bullseye",
-				"3.2-bullseye",
+                "3.3-bullseye",
+                "3.2-bullseye",
                 "3.1-bullseye"
             ],
             "default": "3.3-bullseye"
@@ -25,5 +25,8 @@
     },
     "platforms": [
         "Ruby"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/rust-postgres/devcontainer-template.json
+++ b/src/rust-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust-postgres",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Rust & PostgreSQL",
     "description": "Develop applications with Rust and PostgreSQL. Includes a Rust application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust-postgres",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon):",
             "proposals": [
-				"bookworm",
+                "bookworm",
                 "bullseye"
             ],
             "default": "bullseye"
@@ -20,5 +20,8 @@
     "platforms": [
         "Rust",
         "PostgreSQL DB"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/rust/devcontainer-template.json
+++ b/src/rust/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Rust",
     "description": "Develop Rust based applications. Includes appropriate runtime args and everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/rust",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon):",
             "proposals": [
-				"bookworm",
+                "bookworm",
                 "bullseye"
             ],
             "default": "bullseye"
@@ -19,5 +19,8 @@
     },
     "platforms": [
         "Rust"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -11,11 +11,11 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
-				"22-bookworm",
-				"22-bullseye",
-				"20-bookworm",
+                "22-bookworm",
+                "22-bullseye",
+                "20-bookworm",
                 "18-bookworm",
-				"20-bullseye",
+                "20-bullseye",
                 "18-bullseye"
             ],
             "default": "22-bookworm"
@@ -24,5 +24,8 @@
     "platforms": [
         "Node.js",
         "TypeScript"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/ubuntu/devcontainer-template.json
+++ b/src/ubuntu/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubuntu",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Ubuntu",
     "description": "A simple Ubuntu container with Git and other common utilities installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ubuntu",
@@ -11,7 +11,7 @@
             "type": "string",
             "description": "Ubuntu version (use ubuntu-22.04 or ubuntu-24.04 on local arm64/Apple Silicon):",
             "proposals": [
-				"noble",
+                "noble",
                 "jammy",
                 "focal"
             ],
@@ -20,5 +20,8 @@
     },
     "platforms": [
         "Any"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }

--- a/src/universal/devcontainer-template.json
+++ b/src/universal/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "universal",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "Default Linux Universal",
     "description": "Use or extend the new Ubuntu-based default, large, multi-language universal container for GitHub Codespaces.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/universal",
@@ -19,5 +19,8 @@
         "Go",
         "Ruby",
         "Conda"
+    ],
+    "optionalPaths": [
+        ".github/*"
     ]
 }


### PR DESCRIPTION
ref: https://github.com/devcontainers/spec/pull/484

Seeds the [`optionalPaths` property](https://github.com/devcontainers/spec/blob/e2d850e48292b19b8beb3575b7e538a7bfdad981/docs/specs/devcontainer-templates.md#the-optionalpaths-property) into all Templates with `.github/*` as its value.

When the dev containers/codespace extensions are updated to support this property, will resolve https://github.com/microsoft/vscode-remote-release/issues/10095,  https://github.com/devcontainers/templates/issues/274.  

Lastly, as I was in each Template I updated the whitespace to be consistent throughout the file
