### PR TITLE
Fix CMake from source reinstall for CMake versions < 3.20

### DIFF
--- a/src/cpp/.devcontainer/reinstall-cmake.sh
+++ b/src/cpp/.devcontainer/reinstall-cmake.sh
@@ -42,7 +42,16 @@ case "${architecture}" in
         ;;
 esac
 
-CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+# Kitware OS naming:
+#     CMake version <  3.20, the OS names begin with an uppercase letter
+#     CMake version >= 3.20, the OS names begin with a lowercase letter
+if [[ "${CMAKE_VERSION}" > "3.20" ]]; then
+    OS_NAME="Linux"
+else
+    OS_NAME="linux"
+fi
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-${OS_NAME}-${ARCH}.sh"
 CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
 TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
 


### PR DESCRIPTION
When downloading the CMake installer script from Kitware, the script's name must have the correct case for the sha256 checksum to be properly verified.