### PR TITLE
Create Symlinks for all CMake Executables when Running reinstall-cmake.sh

### DIFF
--- a/src/cpp-mariadb/.devcontainer/reinstall-cmake.sh
+++ b/src/cpp-mariadb/.devcontainer/reinstall-cmake.sh
@@ -55,4 +55,8 @@ curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/
 sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
 sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
 
+ln -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/cmake-gui /usr/local/bin/cmake-gui
+ln -s /opt/cmake/bin/cpack /usr/local/bin/cpack
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest

--- a/src/cpp/.devcontainer/reinstall-cmake.sh
+++ b/src/cpp/.devcontainer/reinstall-cmake.sh
@@ -55,5 +55,8 @@ curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/
 sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
 sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
 
+ln -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/cmake-gui /usr/local/bin/cmake-gui
+ln -s /opt/cmake/bin/cpack /usr/local/bin/cpack
 ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest


### PR DESCRIPTION
When running "reinstall-cmake.sh" when building a container, 5 executables get built in the _/opt/cmake/bin_ folder: ccmake, cmake, cmake-gui, ctest, and cpack. However, only a subset get symlinks created so they are linked in _/usr/local/bin_ and findable on the PATH. This adds the rest.

This is similar to #140 