### PR TITLE
Add extra info about test database connection

### DIFF
--- a/src/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/src/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -40,6 +40,15 @@ services:
       #    username: postgres
       #    password: postgres
       #    database: myapp_development
+      #
+      #  ...
+      #
+      #  test:
+      #    <<: *default
+      #    host: db
+      #    username: postgres
+      #    password: postgres
+      #    database: myapp_test
 
     # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)


### PR DESCRIPTION
I've been trying to get this to work myself, and I didn't realize that you needed to also configure the test database to also connect to the postgres database. Rails kept giving me some errors that didn't really specify that the test database wasn't connecting.

Error if without test database connection set:
```
$ rails db:prepare
bin/rails aborted!
ActiveRecord::ConnectionNotEstablished: could not connect to server: No such file or directory (ActiveRecord::ConnectionNotEstablished)
        Is the server running locally and accepting
        connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?


Caused by:
PG::ConnectionBad: could not connect to server: No such file or directory (PG::ConnectionBad)
        Is the server running locally and accepting
        connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?

Tasks: TOP => db:prepare
(See full trace by running task with --trace)
```

So here's an extra little bit in the docker-compose.yml that states to also append to the test database.