### PR TITLE
[go, go-postgres] - v1.22 eol

### DIFF
--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -13,10 +13,8 @@
             "proposals": [
                 "1-bookworm",
 				"1.23-bookworm",
-                "1.22-bookworm",
                 "1-bullseye",
-				"1.23-bullseye",
-                "1.22-bullseye"
+				"1.23-bullseye"
             ],
             "default": "1.23-bookworm"
         }

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -13,10 +13,8 @@
             "proposals": [
                 "1-bookworm",
 				"1.23-bookworm",
-                "1.22-bookworm",
                 "1-bullseye",
-				"1.23-bullseye",
-                "1.22-bullseye"
+				"1.23-bullseye"
             ],
             "default": "1.23-bookworm"
         }


### PR DESCRIPTION
Templates

Go, Go-Postgres
Description

The Pull Request aims to remove the EOL version v1.22 from the list of go version
Checklist

 checked that applied changes work as expected