### PR TITLE
add vscode extension robole.markdown-shortcuts

### DIFF
--- a/src/markdown/.devcontainer/devcontainer.json
+++ b/src/markdown/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
 				"streetsidesoftware.code-spell-checker",
 				"DavidAnson.vscode-markdownlint",
 				"shd101wyy.markdown-preview-enhanced",
-				"bierner.github-markdown-preview"
+				"bierner.github-markdown-preview",
+				"robole.markdown-shortcuts"
 			]
 		}
 	}


### PR DESCRIPTION
[Markdown Shortcuts](https://marketplace.visualstudio.com/items?itemName=robole.markdown-shortcuts)