### PR TITLE
[ruby, ruby-rails-postgres] - v3.1 eol

### DIFF
--- a/src/ruby-rails-postgres/devcontainer-template.json
+++ b/src/ruby-rails-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby-rails-postgres",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "name": "Ruby on Rails & Postgres",
     "description": "Develop Ruby on Rails applications with Postgres. Includes a Rails application container and PostgreSQL server.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby-rails-postgres",
@@ -15,14 +15,12 @@
                 "3.4-bookworm",
                 "3.3-bookworm",
                 "3.2-bookworm",
-                "3.1-bookworm",
                 "3-bullseye",
                 "3.4-bullseye",				
                 "3.3-bullseye",
-                "3.2-bullseye",
-                "3.1-bullseye"
+                "3.2-bullseye"
             ],
-            "default": "3.3-bullseye"
+            "default": "3.4-bullseye"
         }
     },
     "platforms": ["Ruby"],

--- a/src/ruby/devcontainer-template.json
+++ b/src/ruby/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "name": "Ruby",
     "description": "Develop Ruby based applications. includes everything you need to get up and running.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ruby",
@@ -15,14 +15,12 @@
                 "3.4-bookworm",				
                 "3.3-bookworm",
                 "3.2-bookworm",
-                "3.1-bookworm",
                 "3-bullseye",
                 "3.4-bullseye",				
                 "3.3-bullseye",
-                "3.2-bullseye",
-                "3.1-bullseye"
+                "3.2-bullseye"
             ],
-            "default": "3.3-bullseye"
+            "default": "3.4-bullseye"
         }
     },
     "platforms": ["Ruby"],


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/images/issues/90

**Templates**

Ruby, Ruby-Rails-Postgres

**Description**

- The Pull Request aims to remove the EOL version 3.1 from the list of Ruby version

**Checklist**

- checked that applied changes work as expected