### PR TITLE
Slim down extensions for markdown container

### DIFF
--- a/src/markdown/.devcontainer/devcontainer.json
+++ b/src/markdown/.devcontainer/devcontainer.json
@@ -14,10 +14,8 @@
 		"vscode": {			
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"yzhang.markdown-all-in-one",
 				"streetsidesoftware.code-spell-checker",
 				"DavidAnson.vscode-markdownlint",
-				"shd101wyy.markdown-preview-enhanced",
 				"bierner.github-markdown-preview"
 			]
 		}


### PR DESCRIPTION
These extensions are fairly heavyweight in that they provide a ton of features. We've also seen a fair number of bugs reported against vscode that are caused by them. I don't think they make sense as defaults