### PR TITLE
[javascript-node, javascript-node-mongo, javascript-node-postgres ,typescript-node] - Node 18 EOL changes.

### DIFF
--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -14,8 +14,7 @@
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -15,9 +15,7 @@
                 "22-bullseye",
                 "20-bookworm",
                 "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -15,9 +15,7 @@
                 "22-bullseye",
                 "20-bookworm",
                 "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
             "default": "22-bookworm"
         }

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -14,9 +14,7 @@
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
             "default": "22-bookworm"
         }


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/images/issues/90

**Templates**

- javascript-node, javascript-node-mongo, javascript-node-postgres ,typescript-node

**Description**

- The Pull Request aims to remove the EOL version 18 from the list of Node version

**Checklist**

- checked that applied changes work as expected