### PR TITLE
[go, go-postgres] Add support for Go 1.24

### DIFF
--- a/src/go-postgres/devcontainer-template.json
+++ b/src/go-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go-postgres",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "name": "Go & PostgreSQL",
     "description": "Use and develop Go + Postgres applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go-postgres",
@@ -12,13 +12,15 @@
             "description": "Go version:",
             "proposals": [
                 "1-bookworm",
-				"1.23-bookworm",
+                "1.24-bookworm",
+                "1.23-bookworm",
                 "1.22-bookworm",
                 "1-bullseye",
-				"1.23-bullseye",
+                "1.24-bullseye",
+                "1.23-bullseye",
                 "1.22-bullseye"
             ],
-            "default": "1.23-bookworm"
+            "default": "1.24-bookworm"
         }
     },
     "platforms": ["Go"],

--- a/src/go/devcontainer-template.json
+++ b/src/go/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "name": "Go",
     "description": "Develop Go based applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/go",
@@ -12,13 +12,15 @@
             "description": "Go version:",
             "proposals": [
                 "1-bookworm",
-				"1.23-bookworm",
+                "1.24-bookworm",
+                "1.23-bookworm",
                 "1.22-bookworm",
                 "1-bullseye",
-				"1.23-bullseye",
+                "1.24-bullseye",
+                "1.23-bullseye",
                 "1.22-bullseye"
             ],
-            "default": "1.23-bookworm"
+            "default": "1.24-bookworm"
         }
     },
     "platforms": ["Go"],


### PR DESCRIPTION
Adds support for Go 1.24 (Feb 2025) to the `go` and `go-postgres` templates. Also fixes tabs vs spaces from a previous change, not sure if that's desired though, as it adds churn.

Release notes: https://tip.golang.org/doc/go1.24