### PR TITLE
[ubuntu] - Ubuntu focal EOL base image.

### DIFF
--- a/src/ubuntu/README.md
+++ b/src/ubuntu/README.md
@@ -7,7 +7,7 @@ A simple Ubuntu container with Git and other common utilities installed.
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Ubuntu version (use ubuntu-22.04 or ubuntu-24.04 on local arm64/Apple Silicon): | string | jammy |
+| imageVariant | Ubuntu version (use ubuntu-22.04 or ubuntu-24.04 on local arm64/Apple Silicon): | string | noble |
 
 This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
 

--- a/src/ubuntu/devcontainer-template.json
+++ b/src/ubuntu/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubuntu",
-    "version": "1.3.3",
+    "version": "2.0.0",
     "name": "Ubuntu",
     "description": "A simple Ubuntu container with Git and other common utilities installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ubuntu",

--- a/src/ubuntu/devcontainer-template.json
+++ b/src/ubuntu/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "ubuntu",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "Ubuntu",
     "description": "A simple Ubuntu container with Git and other common utilities installed.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/ubuntu",
@@ -12,10 +12,9 @@
             "description": "Ubuntu version (use ubuntu-22.04 or ubuntu-24.04 on local arm64/Apple Silicon):",
             "proposals": [
                 "noble",
-                "jammy",
-                "focal"
+                "jammy"
             ],
-            "default": "jammy"
+            "default": "noble"
         }
     },
     "platforms": ["Any"],


### PR DESCRIPTION
**Ref:** #90 , [#261](https://github.com/devcontainers/internal/issues/261)

**Description:** The ubuntu focal is going out of support from May 31, 2025. So removing the ubuntu focal from the base image template.

**Changelog:** The following changes have been made.
- Removed ubuntu focal from the devcontainer-template.json

**Checklist:**
- [x] All checks are passed.