### PR TITLE
[cpp, cpp-mariadb] Change to remove ubuntu focal references from c++ image templates

### DIFF
--- a/src/cpp-mariadb/devcontainer-template.json
+++ b/src/cpp-mariadb/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp-mariadb",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "name": "C++ & MariaDB",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp-mariadb",
@@ -14,8 +14,7 @@
                 "debian-12",
                 "debian-11",
                 "ubuntu-24.04",
-                "ubuntu-22.04",
-                "ubuntu-20.04"
+                "ubuntu-22.04"
             ],
             "default": "debian-11"
         },

--- a/src/cpp/devcontainer-template.json
+++ b/src/cpp/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "cpp",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "name": "C++",
     "description": "Develop C++ applications on Linux. Includes Debian C++ build tools.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/cpp",
@@ -14,8 +14,7 @@
                 "debian-12",
                 "debian-11",
                 "ubuntu-24.04",
-                "ubuntu-22.04",
-                "ubuntu-20.04"
+                "ubuntu-22.04"
             ],
             "default": "debian-11"
         },


### PR DESCRIPTION
**Ref:** #90 , [#261](https://github.com/devcontainers/internal/issues/261)

**Description:** The ubuntu focal is going out of support from May 31, 2025. So removing the ubuntu focal from the c++ related image template.

**Changelog:** The following changes have been made.
- Removed ubuntu focal from the devcontainer-template.json for cpp & cpp-mariadb templates

**Checklist:**
- [x] All checks are passed.