### PR TITLE
[javascript-node, javascript-node-mongo, javascript-node-postgres] - Add support for debian trixie(13)

### DIFF
--- a/src/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/src/javascript-node-mongo/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}
+FROM mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}
 
 # Install MongoDB command line tools - though mongo-database-tools not available on arm64
 ARG MONGO_TOOLS_VERSION=6.0

--- a/src/javascript-node-mongo/README.md
+++ b/src/javascript-node-mongo/README.md
@@ -7,7 +7,7 @@ Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Node.js version (use -bullseye variants on local arm64/Apple Silicon): | string | 22-bookworm |
+| imageVariant | Node.js version (use -trixie, -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 24-trixie |
 
 This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
 

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -11,13 +11,17 @@
             "type": "string",
             "description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+				"24-trixie",
+                "24-bookworm",
+                "24-bullseye",	
+				"22-trixie",							
                 "22-bookworm",
                 "22-bullseye",
+				"20-trixie",				
                 "20-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [

--- a/src/javascript-node-postgres/.devcontainer/Dockerfile
+++ b/src/javascript-node-postgres/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}
+FROM mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/javascript-node-postgres/README.md
+++ b/src/javascript-node-postgres/README.md
@@ -7,7 +7,7 @@ Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and ya
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 22-bookworm |
+| imageVariant | Node.js version (use -trixie, -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 24-trixie |
 
 This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
 

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -11,15 +11,17 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+				"24-trixie",
+                "24-bookworm",
+                "24-bullseye",	
+				"22-trixie",			
                 "22-bookworm",
                 "22-bullseye",
+				"20-trixie",
                 "20-bookworm",
-                "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [

--- a/src/javascript-node/.devcontainer/devcontainer.json
+++ b/src/javascript-node/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}"
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/src/javascript-node/README.md
+++ b/src/javascript-node/README.md
@@ -7,7 +7,7 @@ Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 22-bookworm |
+| imageVariant | Node.js version (use -trixie, -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 24-trixie |
 
 This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
 

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -11,15 +11,17 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+                "24-trixie",				
+                "24-bookworm",
+                "24-bullseye",	
+                "22-trixie",							
                 "22-bookworm",
                 "22-bullseye",
+                "20-trixie",				
                 "20-bookworm",
-                "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/internal/issues/283

**Devcontainer Templates:**

- javascript-node
- javascript-node-mongo
- javascript-node-postgres

**Description of changes:** 

- Aims to add support for debian trixie (13)

**Changelog:**

- Change in Dockerfiles to add debian trixie as the default option.
- Change in devcontainer-template.json to add debian trixie image variant.
- Change in readme file.

**Checklist:**
- [x] All checks are passed. 