### PR TITLE
[typescript-node]-Add support for debian trixie(13)

### DIFF
--- a/src/typescript-node/.devcontainer/devcontainer.json
+++ b/src/typescript-node/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-${templateOption:imageVariant}"
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:4-${templateOption:imageVariant}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/src/typescript-node/README.md
+++ b/src/typescript-node/README.md
@@ -7,7 +7,7 @@ Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm,
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| imageVariant | Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 22-bookworm |
+| imageVariant | Node.js version (use -trixie, -bookworm, -bullseye variants on local arm64/Apple Silicon): | string | 24-trixie |
 
 This template references an image that was [pre-built](https://containers.dev/implementors/reference/#prebuilding) to automatically include needed devcontainer.json metadata.
 

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -11,14 +11,17 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+				"24-trixie",
+				"24-bookworm",
+				"24-bullseye",
+				"22-trixie",
                 "22-bookworm",
                 "22-bullseye",
+				"20-trixie",
                 "20-bookworm",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [


### PR DESCRIPTION
Ref: https://github.com/devcontainers/internal/issues/283

Devcontainer Templates:

typescript-node

Description of changes:

Aims to add support for debian trixie (13)
Changelog:

Change in devcontainer-template.json to add debian trixie as the default option.
Change in devcontainer.json to add debian trixie image variant.
Change in readme file.
Checklist:

 All checks are passed.