### PR TITLE
Remove /data from postgres volume path

### DIFF
--- a/src/postgres/.devcontainer/docker-compose.yml
+++ b/src/postgres/.devcontainer/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres


### PR DESCRIPTION
Currently PG container fails to start with a long message: "
in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.
       See also https://github.com/docker-library/postgres/pull/1259⁠
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).
       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.
       See https://github.com/docker-library/postgres/issues/37⁠ for a (long)
       discussion around this process, and suggestions for how to do so.
"
According to that, you should have "a single mount at /var/lib/postgresql", so this is that change Tested on a local single container of postgres:latest, works