### PR TITLE
[ruby, ruby-rails-postgres] - Update postgres volume path to support v18+

### DIFF
--- a/src/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/src/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./create-db-user.sql:/docker-entrypoint-initdb.d/create-db-user.sql
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
The official Docker image for PostgreSQL has changed its recommended volume configuration starting with version 18.

Previously, the data volume was mounted at `/var/lib/postgresql/data`. In newer versions, the `PGDATA` environment variable is version-specific (e.g., `/var/lib/postgresql/18/docker`), and the recommended volume mount point is now `/var/lib/postgresql`.

This pr updates the `docker-compose.yml` to reflect the new recommended practice, ensuring compatibility with PostgreSQL 18 and later.

https://hub.docker.com/_/postgres