### PR TITLE
Add Node.js v24 and update default variant to use it

### DIFF
--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -11,13 +11,15 @@
             "type": "string",
             "description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+                "24-bookworm",
+                "24-bullseye",
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
                 "20-bullseye",
                 "18-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-bookworm"
         }
     },
     "platforms": [

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -11,6 +11,8 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+                "24-bookworm",
+                "24-bullseye",
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
@@ -19,7 +21,7 @@
                 "20-bullseye",
                 "18-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-bookworm"
         }
     },
     "platforms": [

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -11,6 +11,8 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+                "24-bookworm",
+                "24-bullseye",
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
@@ -19,7 +21,7 @@
                 "20-bullseye",
                 "18-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-bookworm"
         }
     },
     "platforms": [

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -11,6 +11,8 @@
             "type": "string",
             "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
             "proposals": [
+                "24-bookworm",
+                "24-bullseye",
                 "22-bookworm",
                 "22-bullseye",
                 "20-bookworm",
@@ -18,7 +20,7 @@
                 "20-bullseye",
                 "18-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-bookworm"
         }
     },
     "platforms": [


### PR DESCRIPTION
Added v24 variants since it's supported in both images now:

- https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list
- https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list

Omitting Trixie (Debian 13) variant since it's currently experimental.

Also updated default to Node 24 which is supported in both Azure functions and Azure web apps now.

Closes #385 