### PR TITLE
[node] - bump versions

### DIFF
--- a/src/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/src/javascript-node-mongo/.devcontainer/Dockerfile
@@ -1,10 +1,11 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}
+FROM mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}
 
 # Install MongoDB command line tools - though mongo-database-tools not available on arm64
-ARG MONGO_TOOLS_VERSION=6.0
+ARG MONGO_VERSION=8.2
 RUN . /etc/os-release \
-    && curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian ${VERSION_CODENAME}/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+    && MONGO_MAJOR_VERSION=$(echo $MONGO_VERSION | cut -d '.' -f 1) \
+    && curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_MAJOR_VERSION}.0.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian ${VERSION_CODENAME}/mongodb-org/${MONGO_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_VERSION}.list \
     && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y mongodb-mongosh \
     && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y mongodb-database-tools; fi \
@@ -20,6 +21,3 @@ RUN . /etc/os-release \
 
 # [Optional] Uncomment if you want to install more global node modules
 # RUN su node -c "npm install -g <your-package-list-here>"
-
-
-

--- a/src/javascript-node-mongo/devcontainer-template.json
+++ b/src/javascript-node-mongo/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-mongo",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & Mongo DB",
     "description": "Develop applications in Node.js and Mongo DB. Includes Node.js, eslint, and yarn in a container linked to a Mongo DB.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo",
@@ -9,15 +9,13 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
-            "proposals": [
+            "description": "Node.js version:",
+            "proposals": [	
+                "24-bookworm",
                 "22-bookworm",
-                "22-bullseye",
-                "20-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "20-bookworm"
             ],
-            "default": "22-bookworm"
+            "default": "24-bookworm"
         }
     },
     "platforms": [

--- a/src/javascript-node-postgres/.devcontainer/Dockerfile
+++ b/src/javascript-node-postgres/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}
+FROM mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/src/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/src/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: 

--- a/src/javascript-node-postgres/devcontainer-template.json
+++ b/src/javascript-node-postgres/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node-postgres",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & PostgreSQL",
     "description": "Develop applications in Node.js and PostgreSQL. Includes Node.js, eslint, and yarn in a container linked to a Postgres DB container",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres",
@@ -9,17 +9,19 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
+            "description": "Node.js version:",
             "proposals": [
+                "24-trixie",
+                "22-trixie",
+                "20-trixie",		
+                "24-bookworm",
                 "22-bookworm",
-                "22-bullseye",
                 "20-bookworm",
-                "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "24-bullseye",
+                "22-bullseye",
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [

--- a/src/javascript-node/.devcontainer/devcontainer.json
+++ b/src/javascript-node/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-${templateOption:imageVariant}"
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:4-${templateOption:imageVariant}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/src/javascript-node/devcontainer-template.json
+++ b/src/javascript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "javascript-node",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & JavaScript",
     "description": "Develop Node.js based applications. Includes Node.js, eslint, nvm, and yarn.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/javascript-node",
@@ -9,17 +9,19 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
+            "description": "Node.js version:",
             "proposals": [
+                "24-trixie",
+                "22-trixie",
+                "20-trixie",		
+                "24-bookworm",
                 "22-bookworm",
-                "22-bullseye",
                 "20-bookworm",
-                "20-bullseye",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "24-bullseye",
+                "22-bullseye",
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [

--- a/src/typescript-node/.devcontainer/devcontainer.json
+++ b/src/typescript-node/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-${templateOption:imageVariant}"
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:4-${templateOption:imageVariant}"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/src/typescript-node/devcontainer-template.json
+++ b/src/typescript-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "typescript-node",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "name": "Node.js & TypeScript",
     "description": "Develop Node.js based applications in TypeScript. Includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/typescript-node",
@@ -9,16 +9,19 @@
     "options": {
         "imageVariant": {
             "type": "string",
-            "description": "Node.js version (use -bookworm, -bullseye variants on local arm64/Apple Silicon):",
+            "description": "Node.js version:",
             "proposals": [
+                "24-trixie",
+                "22-trixie",
+                "20-trixie",		
+                "24-bookworm",
                 "22-bookworm",
-                "22-bullseye",
                 "20-bookworm",
-                "18-bookworm",
-                "20-bullseye",
-                "18-bullseye"
+                "24-bullseye",
+                "22-bullseye",
+                "20-bullseye"
             ],
-            "default": "22-bookworm"
+            "default": "24-trixie"
         }
     },
     "platforms": [


### PR DESCRIPTION
Use Node v24 LTS on Debian 13 by default in the following templates: javascript-node, javascript-node-postres, typescript-node

Use Node v24 LTS on Debian 12 by default in javascript-node-mongo template. Bump MongoDB version to 8.2. Remove obsolete 'version' configuration option from docker-compose.yml