### PR TITLE
[java-postgres] - Correct the volume mount path to support the latest version of postgres

### DIFF
--- a/src/java-postgres/.devcontainer/docker-compose.yml
+++ b/src/java-postgres/.devcontainer/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       # NOTE: POSTGRES_DB/USER/PASSWORD should match values in app container
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Fixes PostgreSQL volume mount path inconsistency in the `java-postgres` template.

The volume path for the `db` service is updated to the standardized mount point: `/var/lib/postgresql`. The current configuration of mounting the volume to `/var/lib/postgresql/data` is now considered legacy. For latest version of PostgreSQL, mounting directly to `/var/lib/postgresql` is the recommended best practice, enabling the container's internal entrypoint to correctly manage the version-specific `PGDATA` subdirectory. This change ensures configuration alignment with the standalone `postgres` template (as established in PR #369) and improves long-term stability.

Verified working in a local development environment.