### PR TITLE
fix(docker): drop obsolete enableNonRootDocker option for docker-in-d…

### DIFF
--- a/src/docker-in-docker/.devcontainer/devcontainer.json
+++ b/src/docker-in-docker/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "${templateOption:dockerVersion}",
-			"enableNonRootDocker": "${templateOption:enableNonRootDocker}",
 			"moby": "${templateOption:moby}"
 		}
 	}

--- a/src/docker-in-docker/README.md
+++ b/src/docker-in-docker/README.md
@@ -11,7 +11,6 @@ Create child containers _inside_ a container, independent from the host's docker
 | upgradePackages | Upgrade OS packages? | boolean | false |
 | dockerVersion | Select or enter a Docker/Moby CLI version. (Availability can vary by OS version.) | string | latest |
 | moby | Install OSS Moby build instead of Docker CE | boolean | true |
-| enableNonRootDocker | Enable non-root user to access Docker in container? | boolean | true |
 
 ## Using this template
 

--- a/src/docker-in-docker/devcontainer-template.json
+++ b/src/docker-in-docker/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "Docker in Docker",
     "description": "Create child containers _inside_ a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/docker-in-docker",
@@ -31,11 +31,6 @@
             "type": "boolean",
             "default": "true",
             "description": "Install OSS Moby build instead of Docker CE"
-        },
-        "enableNonRootDocker": {
-            "type": "boolean",
-            "description": "Enable non-root user to access Docker in container?",
-            "default": "true"
         }
     },
     "platforms": ["Any"],

--- a/src/kubernetes-helm-minikube/.devcontainer/devcontainer.json
+++ b/src/kubernetes-helm-minikube/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"enableNonRootDocker": "true",
 			"moby": "true"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {

--- a/src/kubernetes-helm-minikube/devcontainer-template.json
+++ b/src/kubernetes-helm-minikube/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "kubernetes-helm-minikube",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "name": "Kubernetes - Minikube-in-Docker",
     "description": "Access an embedded minikube instance from inside a dev container. Includes kubectl, Helm, minikube, and the Docker.",
     "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/kubernetes-helm-minikube",

--- a/test/kubernetes-helm-minikube/test.sh
+++ b/test/kubernetes-helm-minikube/test.sh
@@ -11,7 +11,7 @@ checkExtension "ms-azuretools.vscode-docker"
 checkExtension "ms-kubernetes-tools.vscode-kubernetes-tools"
 check "docker" docker ps -a
 check "kubectl" kubectl version --client
-check "helm" helm version --client
+check "helm" helm version --short
 check "minikube start" minikube start
 check "minikube remove" minikube delete
 docker image prune -a -f


### PR DESCRIPTION
# Title
Remove stale Docker in Docker option wiring and update Helm smoke test compatibility

# Problem
A stale template option, `enableNonRootDocker`, was still being surfaced and forwarded in places that use the Docker in Docker feature. The current Docker in Docker feature option set does not include this option.
The Same was reported at https://github.com/devcontainers/templates/issues/436

This mismatch caused two issues:
1. Configuration drift between template options and feature options.
2. Confusing behavior for users who see an option that is not actually supported by the underlying feature.

During validation, one smoke test also failed for an unrelated compatibility reason: the Helm command in the Kubernetes Minikube test used `helm version --client`, which is not supported by current Helm releases.

# Fix Summary
This change removes stale `enableNonRootDocker` usage only where it is tied to Docker in Docker, keeps valid usage for Docker outside of Docker intact, and updates one test command for Helm CLI compatibility.

Specifically:
1. Removed `enableNonRootDocker` from the Docker in Docker template option list.
2. Removed forwarding of `enableNonRootDocker` to the Docker in Docker feature in template devcontainer configs.
3. Updated generated template documentation to remove the stale option row.
4. Removed stale Docker in Docker option usage from Kubernetes Minikube template configuration.
5. Updated Kubernetes Minikube smoke test to use `helm version --short`.
6. Bumped template patch versions for changed templates.

# Tests
Smoke tests were run for both affected templates using the same local harness flow in both the affected repos- docker-in-docker & kubernetes-helm-minikube.

# Impact
This change improves correctness and clarity of template configuration.

User impact:
1. Users no longer see or pass a stale Docker in Docker option that is unsupported by the feature.
2. Kubernetes Minikube smoke tests remain green on current Helm versions.
3. Valid `enableNonRootDocker` usage for Docker outside of Docker remains unchanged.

