### PR TITLE
Use GitHub App token instead of PAT in update-documentation workflow

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -10,11 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: documentation
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: "github.ref == 'refs/heads/main'"
     steps:
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEVCONTAINERS_REPO_AUTOMATION_ID }}
+          private-key: ${{ secrets.DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate Documentation
         uses: devcontainers/action@v1
@@ -25,7 +33,7 @@ jobs:
       - name: Create a PR for Documentation
         id: push_image_info
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           echo "Start."
@@ -51,7 +59,7 @@ jobs:
                 -H "Accept: application/vnd.github+json" \
                 /repos/${GITHUB_REPOSITORY}/pulls \
                 -f title="$message" \
-              -f body="$message" \
-              -f head="$branch" \
-              -f base='main'
+                -f body="$message" \
+                -f head="$branch" \
+                -f base='main'
           fi


### PR DESCRIPTION
## Use the `devcontainers-repos-automation` GitHub App token instead of a PAT

### What
Replaces the fine-grained PAT (`secrets.PAT`) in `.github/workflows/update-documentation.yml` with a short-lived GitHub App installation token minted at runtime via `actions/create-github-app-token`.

### Why
Microsoft open source now caps PAT lifetime at 8 days (down from 3 months), which would force an 8-day rotation cadence. The App private key has no forced expiry, and the installation token it mints is automatically short-lived (~1h) and rotated every run. A PR opened under the App identity still triggers downstream required checks (unlike the built-in `GITHUB_TOKEN`). See devcontainers/internal#343.

This mirrors the change made in `devcontainers/images` (see that repo's release-workflow PR).

### How it works
The `generate` job now:
1. Mints a token with `actions/create-github-app-token@v2` using `vars.DEVCONTAINERS_REPO_AUTOMATION_ID` (org variable) and `secrets.DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY` (org secret, scoped to this repo).
2. Uses that token for `actions/checkout` (so `git push` is attributed to the App) and for the `git push` / `gh api .../pulls` step in place of `secrets.PAT`.
3. Default `GITHUB_TOKEN` permissions reduced to `contents: read` (the App token performs all writes).

### Testing
Validated the App-token setup in `devcontainers/templates` before merge using a throwaway push-triggered workflow on a temporary branch (auto-cleaned up — no changes to `main`): [run 30543176813](https://github.com/devcontainers/templates/actions/runs/30543176813). It confirmed token minting (installation scoped to this repo), read access, `contents: write` (created + deleted a temp ref), and `pull-requests: write` (opened a draft PR via `gh api POST /pulls`, then auto-closed it and deleted the temporary branches). All test branches and the temporary test PR were closed/deleted; no artifacts remain.

### Prerequisites
- `devcontainers-repos-automation` GitHub App installed on `devcontainers/templates` (Contents R/W, Pull requests R/W, Issues R/W, Metadata R).
- Org variable `DEVCONTAINERS_REPO_AUTOMATION_ID` and org secret `DEVCONTAINERS_REPO_AUTOMATION_PRIVATE_KEY` scoped to this repo.

### Notes / follow-ups
- `secrets.PAT` can be removed from the repo once this is merged and a documentation run is verified green.
- Consider pinning `actions/create-github-app-token` to a full commit SHA if the repo adopts action pinning.
